### PR TITLE
Complete the vanniktech publishing migration

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -24,6 +24,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history + tags so axion-release resolves the snapshot version.
+          fetch-depth: 0
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -31,10 +34,10 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
-      - name: Execute Gradle build
-        run: ./gradlew build -x test publish
+      - name: Publish snapshot to Central Portal
+        run: ./gradlew publishToMavenCentral --no-configuration-cache
         env:
-          GPR_USERNAME: benfortuna
-          GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ plugins {
     id 'pl.allegro.tech.build.axion-release' version '1.20.1'
     id 'biz.aQute.bnd.builder' version "$bndVersion" apply false
     id 'com.vanniktech.maven.publish' version '0.34.0' apply false
-    id 'signing'
 }
 
 scmVersion {
@@ -54,10 +53,6 @@ configure(subprojects) {
 Manipulate iCalendar data
 '''
     version = rootProject.scmVersion.version
-
-    ext {
-        isReleaseVersion = !version.endsWith("SNAPSHOT")
-    }
 
     java {
         sourceCompatibility = 17
@@ -93,50 +88,38 @@ Manipulate iCalendar data
         testRuntimeOnly libs.junit.platform
     }
 
-    ext {
-        isReleaseVersion = !version.endsWith("SNAPSHOT")
-    }
+    // Publishing to the Sonatype Central Portal is configured via the vanniktech plugin.
+    // Host, auto-release and signing toggles live in gradle.properties
+    // (SONATYPE_HOST, SONATYPE_AUTOMATIC_RELEASE, RELEASE_SIGNING_ENABLED).
+    // Credentials and the signing key are supplied via ORG_GRADLE_PROJECT_* env vars in CI.
+    mavenPublishing {
+        coordinates(group.toString(), project.name, version.toString())
 
-    publishing {
-        publications {
-            ical4j_command(MavenPublication) {
-                from components.java
-                pom.withXml {
-                    asNode().appendNode('name', project.name)
-                    asNode().appendNode('description', project.description)
-                    asNode().appendNode('url', 'http://ical4j.github.io')
+        pom {
+            name = project.name
+            description = project.description
+            url = 'http://ical4j.github.io'
 
-                    def scmNode = asNode().appendNode('scm')
-                    scmNode.appendNode('url', 'https://github.com/ical4j/ical4j-command')
-                    scmNode.appendNode('connection', 'scm:git@github.com:ical4j/ical4j-command.git')
-                    scmNode.appendNode('developerConnection', 'scm:git@github.com:ical4j/ical4j-command.git')
-
-                    def licenseNode = asNode().appendNode('licenses').appendNode('license')
-                    licenseNode.appendNode('name', 'iCal4j - License')
-                    licenseNode.appendNode('url', 'https://raw.githubusercontent.com/ical4j/ical4j/master/LICENSE')
-                    licenseNode.appendNode('distribution', 'repo')
-
-                    def developerNode = asNode().appendNode('developers').appendNode('developer')
-                    developerNode.appendNode('id', 'fortuna')
-                    developerNode.appendNode('name', 'Ben Fortuna')
+            licenses {
+                license {
+                    name = 'iCal4j - License'
+                    url = 'https://raw.githubusercontent.com/ical4j/ical4j/master/LICENSE'
+                    distribution = 'repo'
                 }
             }
-        }
 
-        repositories {
-            maven {
-                name = "OSSRH"
-                url = !isReleaseVersion ? "https://central.sonatype.com/repository/maven-snapshots/" : "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
-                credentials {
-                    username = System.getenv("MAVEN_USERNAME")
-                    password = System.getenv("MAVEN_PASSWORD")
+            developers {
+                developer {
+                    id = 'fortuna'
+                    name = 'Ben Fortuna'
                 }
             }
-        }
-    }
 
-    signing {
-        required = { isReleaseVersion }
-        sign publishing.publications.ical4j_command
+            scm {
+                url = 'https://github.com/ical4j/ical4j-command'
+                connection = 'scm:git@github.com:ical4j/ical4j-command.git'
+                developerConnection = 'scm:git@github.com:ical4j/ical4j-command.git'
+            }
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,9 @@
 bndVersion = 7.1.0
+
+# Maven Central publishing (vanniktech maven-publish plugin).
+# Credentials and the signing key are provided via ORG_GRADLE_PROJECT_* env vars in CI:
+#   ORG_GRADLE_PROJECT_mavenCentralUsername / ORG_GRADLE_PROJECT_mavenCentralPassword
+#   ORG_GRADLE_PROJECT_signingInMemoryKey   / ORG_GRADLE_PROJECT_signingInMemoryKeyPassword
+SONATYPE_HOST=CENTRAL_PORTAL
+SONATYPE_AUTOMATIC_RELEASE=true
+RELEASE_SIGNING_ENABLED=true


### PR DESCRIPTION
Part of the [standardise-build-publishing](https://github.com/ical4j/ical4j/blob/develop/openspec/changes/standardise-build-publishing/proposal.md) change (tasks 1.5/3.6) — completes the migration this repo already had in progress.

## What
- Adds the `mavenPublishing { pom { … } }` block per subproject (`core`, `cli`, `mcp`), carrying over the exact values from the legacy `pom.withXml`.
- Deletes the legacy `publishing {}`/`signing {}` blocks that coexisted with the vanniktech plugin (they would have produced duplicate publications), the duplicated `ext.isReleaseVersion`, and the leftover root `signing` plugin.
- Adds `SONATYPE_HOST=CENTRAL_PORTAL` / `SONATYPE_AUTOMATIC_RELEASE` / `RELEASE_SIGNING_ENABLED` to `gradle.properties`.
- Snapshot workflow moved to the ecosystem pattern: `publishToMavenCentral` with `ORG_GRADLE_PROJECT_*` credentials (org-level secrets already provisioned).

## Verification
- Per-module POM diff (legacy publication vs vanniktech): semantically identical for all three modules.
- `./gradlew build` green on Gradle 9.2.1 (the repo could not even configure at the pre-WIP HEAD — axion 1.13.6 vs Gradle 9).

Merging to develop triggers this repo's first Central Portal snapshot publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaN5r49Rzce1uZRwE9GKqq